### PR TITLE
[FIX] Fix New Migration

### DIFF
--- a/database/migrations/20220617013234-create-new.js
+++ b/database/migrations/20220617013234-create-new.js
@@ -21,9 +21,6 @@ module.exports = {
         type: Sequelize.STRING
       },
       categoryId: {
-        type: Sequelize.INTEGER
-      },
-      categoryId: {
         type: Sequelize.INTEGER,
         references:{
           model:'Categories',


### PR DESCRIPTION
### Description
Elimine el campo categoryId de la migracion de news. Este se repite 2 veces

### Evidence 
La migracion de news  se sigue haciendo correctamente.

![table_news](https://user-images.githubusercontent.com/44248035/175660277-51ab6729-9cfd-46d9-ad5b-102aba645052.png)

