### PR TITLE
[UPDATE] OT226-51 Return the token to the user after registering on the site

### DIFF
--- a/services/users.js
+++ b/services/users.js
@@ -53,7 +53,8 @@ exports.registerUser = async (body) => {
     if (!user || user.length === 0) {
       throw new ErrorObject('User not created', 404)
     }
-    return user
+    const token = createJWT(user)
+    return { ...user.dataValues, token }
   } catch (error) {
     throw new ErrorObject(error.message, error.statusCode || 500)
   }


### PR DESCRIPTION
CARD [OT226-51](https://alkemy-labs.atlassian.net/browse/OT226-51)

<hr>

## Description

* AS an authenticated user
* I WANT to obtain an authentication token
* TO keep me logged into the system

### Acceptance criteria:

When the user registers on the site, he/she should be logged in automatically For this, it is necessary to modify the registration endpoint to return the token once the user is created, as the token will be stored on the client side.

<hr>

## Evidence

**REGISTER TOKEN**
![registerToken](https://user-images.githubusercontent.com/75815125/176276957-768280f4-086e-4651-975d-307bb91cea0d.PNG)
