### PR TITLE
[ENDPOINT] - OT226-57 - Get /slides

### DIFF
--- a/controllers/slides.js
+++ b/controllers/slides.js
@@ -1,0 +1,24 @@
+const createHttpError = require('http-errors')
+const { getSlides } = require('../services/slides')
+const { endpointResponse } = require('../helpers/success')
+const { catchAsync } = require('../helpers/catchAsync')
+
+// example of a controller. First call the service, then build the controller method
+module.exports = {
+  get: catchAsync(async (req, res, next) => {
+    try {
+      const response = await getSlides()
+      endpointResponse({
+        res,
+        message: 'slides retrieved successfully',
+        body: response,
+      })
+    } catch (error) {
+      const httpError = createHttpError(
+        error.statusCode,
+        `[Error retrieving index] - [index - GET]: ${error.message}`,
+      )
+      next(httpError)
+    }
+  }),
+}

--- a/routes/index.js
+++ b/routes/index.js
@@ -7,6 +7,7 @@ const userRouter = require('./users')
 const authRouter = require('./auth')
 const activityRouter = require('./activities')
 const contactRouter = require('./contacts')
+const slideRouter = require('./slides')
 
 const router = express.Router()
 
@@ -19,5 +20,6 @@ router.use('/users', userRouter)
 router.use('/auth', authRouter)
 router.use('/activities', activityRouter)
 router.use('/contacts', contactRouter)
+router.use('/slides', slideRouter)
 
 module.exports = router

--- a/routes/slides.js
+++ b/routes/slides.js
@@ -1,0 +1,11 @@
+const express = require('express')
+// const { schemaValidator } = require('../middlewares/validator')
+const { get } = require('../controllers/slides')
+const { verifyUsers } = require('../middlewares/auth')
+const { isAdmin } = require('../middlewares/isAdmin')
+
+const router = express.Router()
+
+router.get('/', verifyUsers, isAdmin, get)
+
+module.exports = router

--- a/services/slides.js
+++ b/services/slides.js
@@ -1,0 +1,15 @@
+const { ErrorObject } = require('../helpers/error')
+const { Slide } = require('../database/models')
+
+// example of a service
+exports.getSlides = async () => {
+  try {
+    const getSlides = await Slide.findAll()
+    if (!getSlides || getSlides.length === 0) {
+      throw new ErrorObject('No index found', 404)
+    }
+    return getSlides
+  } catch (error) {
+    throw new ErrorObject(error.message, error.statusCode || 500)
+  }
+}


### PR DESCRIPTION
## [OT226-57](https://alkemy-labs.atlassian.net/browse/OT226-57)

## OT226-57- ENDPOINT Get /slides

### Description
- AS admin user
- I WANT to see the Slides listings
- TO view the content graphically.

### Criteria of acceptance:

A GET request must be made to /Slides.

It will return the list of Slides, with the thumbnail and the same order

## Evidences

- Get /slides without Token in the request
<img width="699" alt="getWithoutToken" src="https://user-images.githubusercontent.com/82002776/176487540-af3ef94e-1fc3-4661-bb24-e78eed039966.PNG">

- Get /slides with Token in the request but as normal user
<img width="705" alt="GETNormalUser" src="https://user-images.githubusercontent.com/82002776/176488253-a70b575a-5acf-4059-b8e7-c2885d756895.PNG">

- Get /slides with Token in the request but as Admin user
<img width="902" alt="getAdminUser" src="https://user-images.githubusercontent.com/82002776/176488454-81d9e992-e1d7-4629-8d44-6c577889fe93.PNG">

