### PR TITLE
[FIX] OT226-51 Return the token to the user after registering on the site

### DIFF
--- a/controllers/users.js
+++ b/controllers/users.js
@@ -38,10 +38,12 @@ module.exports = {
       body.roleId = 1
 
       const users = await registerUser(body)
+      const [user, token] = users
       endpointResponse({
         res,
         message: 'Users created successfully',
-        body: users,
+        body: user,
+        token,
       })
     } catch (error) {
       const httpError = createHttpError(

--- a/controllers/users.js
+++ b/controllers/users.js
@@ -38,12 +38,11 @@ module.exports = {
       body.roleId = 1
 
       const users = await registerUser(body)
-      const [user, token] = users
       endpointResponse({
         res,
         message: 'Users created successfully',
-        body: user,
-        token,
+        body: users.user,
+        token: users.token,
       })
     } catch (error) {
       const httpError = createHttpError(

--- a/helpers/success.js
+++ b/helpers/success.js
@@ -1,5 +1,5 @@
 const endpointResponse = ({
-  res, code = 200, status = true, message, body, options,
+  res, code = 200, status = true, message, body, options, token
 }) => {
   res.status(code).json({
     code,
@@ -7,6 +7,7 @@ const endpointResponse = ({
     message,
     body,
     options,
+    token
   })
 }
 

--- a/helpers/success.js
+++ b/helpers/success.js
@@ -1,5 +1,5 @@
 const endpointResponse = ({
-  res, code = 200, status = true, message, body, options, token
+  res, code = 200, status = true, message, body, options, token,
 }) => {
   res.status(code).json({
     code,
@@ -7,7 +7,7 @@ const endpointResponse = ({
     message,
     body,
     options,
-    token
+    token,
   })
 }
 

--- a/services/users.js
+++ b/services/users.js
@@ -54,7 +54,9 @@ exports.registerUser = async (body) => {
       throw new ErrorObject('User not created', 404)
     }
     const token = createJWT(user)
-    return { ...user.dataValues, token }
+
+    const data = [user, token]
+    return data
   } catch (error) {
     throw new ErrorObject(error.message, error.statusCode || 500)
   }

--- a/services/users.js
+++ b/services/users.js
@@ -54,9 +54,7 @@ exports.registerUser = async (body) => {
       throw new ErrorObject('User not created', 404)
     }
     const token = createJWT(user)
-
-    const data = [user, token]
-    return data
+    return { user, token }
   } catch (error) {
     throw new ErrorObject(error.message, error.statusCode || 500)
   }


### PR DESCRIPTION
FIX CARD [OT226-51](https://alkemy-labs.atlassian.net/browse/OT226-51)

<hr>

## Description

* AS an authenticated user
* I WANT to obtain an authentication token
* TO keep me logged into the system

### Acceptance criteria:

When the user registers on the site, he/she should be logged in automatically For this, it is necessary to modify the registration endpoint to return the token once the user is created, as the token will be stored on the client side.

<hr>

## Evidence

**FIX TOKEN**
![fixToken](https://user-images.githubusercontent.com/75815125/176585972-b703396b-4df1-41af-91d3-618edc91a9f8.PNG)
