### PR TITLE
[ENDPOINT] Delete /slides/:id - OT226-61

### DIFF
--- a/controllers/slides.js
+++ b/controllers/slides.js
@@ -1,5 +1,5 @@
 const createHttpError = require('http-errors')
-const { getSlides } = require('../services/slides')
+const { getSlides, deleteSlide } = require('../services/slides')
 const { endpointResponse } = require('../helpers/success')
 const { catchAsync } = require('../helpers/catchAsync')
 
@@ -17,6 +17,22 @@ module.exports = {
       const httpError = createHttpError(
         error.statusCode,
         `[Error retrieving index] - [index - GET]: ${error.message}`,
+      )
+      next(httpError)
+    }
+  }),
+  destroy: catchAsync(async (req, res, next) => {
+    try {
+      const response = await deleteSlide(req.params.id)
+      endpointResponse({
+        res,
+        message: 'slides deleted succesfully',
+        body: response,
+      })
+    } catch (error) {
+      const httpError = createHttpError(
+        error.statusCode,
+        `[Error deleting Slide] - [index - DELETE]: ${error.message}`,
       )
       next(httpError)
     }

--- a/routes/slides.js
+++ b/routes/slides.js
@@ -1,11 +1,12 @@
 const express = require('express')
 // const { schemaValidator } = require('../middlewares/validator')
-const { get } = require('../controllers/slides')
+const { get, destroy } = require('../controllers/slides')
 const { verifyUsers } = require('../middlewares/auth')
 const { isAdmin } = require('../middlewares/isAdmin')
 
 const router = express.Router()
 
 router.get('/', verifyUsers, isAdmin, get)
+router.delete('/:id', verifyUsers, isAdmin, destroy)
 
 module.exports = router

--- a/services/slides.js
+++ b/services/slides.js
@@ -13,3 +13,15 @@ exports.getSlides = async () => {
     throw new ErrorObject(error.message, error.statusCode || 500)
   }
 }
+
+exports.deleteSlide = async (idSlide) => {
+  try {
+    const slide = await Slide.destroy({ where: { id: idSlide } })
+    if (!slide || slide.length === 0) {
+      throw new ErrorObject('No index found', 404)
+    }
+    return slide
+  } catch (error) {
+    throw new ErrorObject(error.message, error.statusCode || 500)
+  }
+}


### PR DESCRIPTION
## [OT226-61](https://alkemy-labs.atlassian.net/browse/OT226-61)

## Endpoint Delete /slides/:id

### Description
- AS admin user
- I WANT to be able to delete Slides
- TO have the updated information at the top of the page

### Criteria of acceptance:

**A DELETE /Slides/:id request must be made**

**must validate that the slide exists and delete it, otherwise return an error**

## Evidences
-  DELETE /Slides/:id without token
<img width="901" alt="request without token" src="https://user-images.githubusercontent.com/82002776/176728869-bdd68fbe-d054-4aca-a7f1-4d5ee7f40bcf.PNG">

-  DELETE /Slides/:id user unauthorized
<img width="909" alt="user unauthorized" src="https://user-images.githubusercontent.com/82002776/176728988-01473bec-3af1-4348-8309-b4493f0a95a7.PNG">

-  DELETE /Slides/:id if id doesnt exist
<img width="913" alt="id doesnt exist" src="https://user-images.githubusercontent.com/82002776/176729092-725ac432-2159-473c-b2cb-970b74435086.PNG">

-  DELETE /Slides/:id delete slide succesfully
<img width="912" alt="slide deleted succesfully" src="https://user-images.githubusercontent.com/82002776/176729170-59fabca8-af12-478b-9b4c-71e481bfa779.PNG">


