### PR TITLE
[MIGRATION ORGANIZATION] - OT226-66 - Add contact fields to organization table

### DIFF
--- a/database/migrations/20220701185303-add-fields-organization.js
+++ b/database/migrations/20220701185303-add-fields-organization.js
@@ -1,0 +1,38 @@
+'use strict';
+
+module.exports = {
+  up: (queryInterface, Sequelize) => {
+    return queryInterface.sequelize.transaction( t => {
+      return Promise.all([
+        queryInterface.addColumn(
+          'Organizations',
+          'facebookUrl', 
+          {
+            type: Sequelize.STRING
+          }, { transaction: t }),
+        queryInterface.addColumn(
+          'Organizations',
+          'instagramUrl', 
+          {
+            type: Sequelize.STRING
+          }, { transaction: t }),
+        queryInterface.addColumn(
+          'Organizations',
+          'linkedinUrl', 
+          {
+            type: Sequelize.STRING
+          }, { transaction: t })
+      ]);
+    });
+  },
+
+  down: async (queryInterface, Sequelize) => {
+    return queryInterface.sequelize.transaction( t => {
+      return Promise.all([
+        queryInterface.removeColumn('Organizations', 'facebookUrl', { transaction: t }),
+        queryInterface.removeColumn('Organizations', 'instagramUrl', { transaction: t }),
+        queryInterface.removeColumn('Organizations', 'linkedinUrl', { transaction: t }),
+      ]);
+    });
+  }
+};

--- a/database/models/organization.js
+++ b/database/models/organization.js
@@ -42,6 +42,15 @@ module.exports = (sequelize, DataTypes) => {
       type: DataTypes.TEXT,
       allowNull: true,
     },
+    facebookUrl: {
+      type: DataTypes.STRING
+    },
+    instagramUrl: {
+      type: DataTypes.STRING
+    },
+    linkedinUrl: {
+      type: DataTypes.STRING
+    },
     deletedAt: DataTypes.DATE
   }, {
     sequelize,


### PR DESCRIPTION
## [OT226-66](https://alkemy-labs.atlassian.net/browse/OT226-66)

## Migration Organization Add Contact Fields

### Description
- AS admin user
- I WANT to edit the contact fields to the Organization
- TO display the information in the best possible way.

### Criteria of acceptance:
**Create a migration to add the social media urls to an Organization. 
You must add Facebook, Linkedin and Instagram url**

## Evidences
- table fileds before run migration
<img width="584" alt="before run migration" src="https://user-images.githubusercontent.com/82002776/176958930-243fe8ca-c82c-4cd9-b1a4-c5f6430f513f.PNG">

- Run Migration Command
<img width="593" alt="run command migration" src="https://user-images.githubusercontent.com/82002776/176959028-2015c434-bc0f-4ffa-9a25-602a8a1a2d0f.PNG">

- table fields after run migration
<img width="515" alt="table after run migration" src="https://user-images.githubusercontent.com/82002776/176959061-7209c5cc-23ca-4903-b640-5c91cfb3f4c3.PNG">


