### PR TITLE
[ENDPOINT] OT226-84 GET /news/:id/comments to receive news comments

### DIFF
--- a/controllers/news.js
+++ b/controllers/news.js
@@ -1,7 +1,7 @@
 const createHttpError = require('http-errors')
 
 const {
-  create, getNews, deleteNews, updateNews,
+  create, getNews, deleteNews, updateNews, getWithComments,
 } = require('../services/news')
 
 const { endpointResponse } = require('../helpers/success')
@@ -69,6 +69,22 @@ module.exports = {
       const httpError = createHttpError(
         error.statusCode,
         `[Error updating the news] - [news - PUT]: ${error.message}`,
+      )
+      next(httpError)
+    }
+  }),
+  getWithComments: catchAsync(async (req, res, next) => {
+    try {
+      const response = await getWithComments(req.params.id)
+      endpointResponse({
+        res,
+        message: 'news with comments retrieved successfully',
+        body: response,
+      })
+    } catch (error) {
+      const httpError = createHttpError(
+        error.statusCode,
+        `[Error retrieved news with comments] - [news with comments - GET]: ${error.message}`,
       )
       next(httpError)
     }

--- a/controllers/news.js
+++ b/controllers/news.js
@@ -1,7 +1,12 @@
 const createHttpError = require('http-errors')
 
 const {
-  create, getNewById, deleteNews, updateNews, getNews, getWithComments
+  create,
+  getNewById,
+  deleteNews,
+  updateNews,
+  getNews,
+  getWithComments,
 } = require('../services/news')
 
 const { endpointResponse } = require('../helpers/success')

--- a/routes/news.js
+++ b/routes/news.js
@@ -1,9 +1,9 @@
 const express = require('express')
 
 const { schemaValidator } = require('../middlewares/validator')
-const { news } = require('../schemas/new')
+const { news, idNews } = require('../schemas/new')
 const {
-  post, get, destroy, put,
+  post, get, destroy, put, getWithComments,
 } = require('../controllers/news')
 const { isAdmin } = require('../middlewares/isAdmin')
 const { verifyUsers } = require('../middlewares/auth')
@@ -14,5 +14,6 @@ router.post('/', verifyUsers, isAdmin, schemaValidator(news), post)
 router.get('/:id', get)
 router.delete('/:id', verifyUsers, isAdmin, destroy)
 router.put('/:id', verifyUsers, isAdmin, put)
+router.get('/:id/comments', verifyUsers, schemaValidator(idNews), getWithComments)
 
 module.exports = router

--- a/schemas/new.js
+++ b/schemas/new.js
@@ -32,3 +32,17 @@ exports.news = {
     },
   },
 }
+
+exports.idNews = {
+  id: {
+    exists: {
+      errorMessage: 'There must be a id',
+    },
+    notEmpty: {
+      errorMessage: 'id is empty',
+    },
+    isInt: {
+      errorMessage: 'The id must be a integer',
+    },
+  },
+}

--- a/services/news.js
+++ b/services/news.js
@@ -1,6 +1,6 @@
 const { ErrorObject } = require('../helpers/error')
 
-const { New, Category } = require('../database/models')
+const { New, Category, Comment } = require('../database/models')
 
 exports.create = async (data) => {
   const {
@@ -56,6 +56,20 @@ exports.updateNews = async (req) => {
 
     const updatedNews = await New.update(req.body, { where: { id } })
     return updatedNews
+  } catch (error) {
+    throw new ErrorObject(error.message, error.statusCode || 500)
+  }
+}
+
+exports.getWithComments = async (idNew) => {
+  try {
+    const getNews = await Comment.findAll({
+      where: { news_id: idNew },
+    })
+    if (!getNews || getNews.length === 0) {
+      throw new ErrorObject('No index found', 404)
+    }
+    return getNews
   } catch (error) {
     throw new ErrorObject(error.message, error.statusCode || 500)
   }


### PR DESCRIPTION
## [OT226-84](https://alkemy-labs.atlassian.net/browse/OT226-84)

## Endpoint GET  /news/:id/comments to receive news comments

### Description
- AS user
- I WANT to view the Comments of a news item
- TO get organized information

Criteria of acceptance:
GET /news/:id/comments - Will return all Comments belonging to a news

## Evidences

- Request without token
<img width="913" alt="request without token" src="https://user-images.githubusercontent.com/82002776/177904765-3650fc2f-000a-4b9c-8e1e-f9cebdc104d6.PNG">

- Request with id invalid
<img width="914" alt="if id is not a integer" src="https://user-images.githubusercontent.com/82002776/177904832-2ba4817c-503a-47e0-af21-b1a84195015c.PNG">

- Request with id does not exist or has not comments
<img width="907" alt="if id news does not exist" src="https://user-images.githubusercontent.com/82002776/177904977-8588758f-c3f7-4a19-85e7-2a13bd569b82.PNG">

- Request Succesfully
<img width="902" alt="request succesfully" src="https://user-images.githubusercontent.com/82002776/177905184-3bb96285-90fe-4198-9205-d358d621df7f.PNG">
<img width="895" alt="request succesfully 1" src="https://user-images.githubusercontent.com/82002776/177905195-38c081f1-8809-490c-8ad2-379437b87163.PNG">




