### PR TITLE
[PAGINATION] OT226-87 Members

### DIFF
--- a/controllers/members.js
+++ b/controllers/members.js
@@ -8,7 +8,7 @@ const { catchAsync } = require('../helpers/catchAsync')
 module.exports = {
   get: catchAsync(async (req, res, next) => {
     try {
-      const response = await getMembers(req.query.page)
+      const response = await getMembers(req)
       endpointResponse({
         res,
         message: 'have been obtained successfully',

--- a/controllers/members.js
+++ b/controllers/members.js
@@ -8,7 +8,7 @@ const { catchAsync } = require('../helpers/catchAsync')
 module.exports = {
   get: catchAsync(async (req, res, next) => {
     try {
-      const response = await getMembers()
+      const response = await getMembers(req.query.page)
       endpointResponse({
         res,
         message: 'have been obtained successfully',

--- a/services/members.js
+++ b/services/members.js
@@ -1,10 +1,18 @@
 const { ErrorObject } = require('../helpers/error')
 const { Member } = require('../database/models')
 
-exports.getMembers = async () => {
+exports.getMembers = async (page) => {
   try {
-    const members = await Member.findAll()
-    return members
+    if (!page) {
+      const members = await Member.findAll({})
+      return members
+    }
+    const pageAsNumber = await Number.parseInt(page, 10)
+    if (!Number.isNaN(pageAsNumber) && pageAsNumber > 0) {
+      const members = await Member.findAll({ offset: pageAsNumber - 1, limit: 10 })
+      return members
+    }
+    throw new ErrorObject('Page parameter must be a number greater than or equal to 1', 500)
   } catch (error) {
     throw new ErrorObject(error.message, error.statusCode || 500)
   }


### PR DESCRIPTION
[OT226-87](https://alkemy-labs.atlassian.net/browse/OT226-87)
### Description
AS A USER
I WANT to visualize the results of paginated Members
TO increase the speed of response

Acceptance Criteria:
When the request is made to list, the results should be paginated by 10. In the response, the results and urls for the previous and next page (if applicable) should be displayed. The current page will be obtained from the query parameter ?page

### Evidence
Page = 1  -- Response Status 200OK
![page1](https://user-images.githubusercontent.com/44248035/177998654-063a8ebc-e9d3-4702-87cb-f6fe2b829372.jpg)
Page = 10 -- Response Status 200OK
![pag10](https://user-images.githubusercontent.com/44248035/177998764-3123939a-1ddb-44e3-985a-6c1874fa4396.jpg)
Page = 0 -- Response Status 500 Error (number must be greater than 0)
![pageError0](https://user-images.githubusercontent.com/44248035/177999049-55b31f3c-04ed-4a52-96c2-c14112697362.jpg)
Page = aaa -- Response Status 500 Error (page parameter must be numeric)
![pageErrorString](https://user-images.githubusercontent.com/44248035/177999343-5e4d700f-bf0f-423c-8ace-3fb2b185d9dc.jpg)
If we do not enter the page parameter. The response returns all members
![members](https://user-images.githubusercontent.com/44248035/177999550-40fbe522-b92f-4de0-ad4f-8a06afac6c26.jpg)

